### PR TITLE
fix: verify NVD TLS certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.6
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Trisha Pancho, 2023-2025
+   Copyright (c) Trisha Pancho, 2023-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: NIST NVD
-Copyright (c) Trisha Pancho, 2023-2025
+Copyright (c) Trisha Pancho, 2023-2026

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This table lists the configuration variables required to operate NIST NVD. These
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 **api_version** | required | string | Supported API Version |
+**verify_server_cert** | optional | boolean | Verify server SSL certificate |
 
 ### Supported Actions
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NIST NVD
 
-Publisher: Trisha Pancho \
-Connector Version: 1.0.1 \
-Product Vendor: NIST \
-Product Name: NVD \
+Publisher: Trisha Pancho <br>
+Connector Version: 1.0.1 <br>
+Product Vendor: NIST <br>
+Product Name: NVD <br>
 Minimum Product Version: 5.3.2.88192
 
 App to query NIST for CVEs
@@ -18,14 +18,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [cve lookup](#action-cve-lookup) - Query NVD for specific CVE ID
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -40,7 +40,7 @@ No Output
 
 Query NVD for specific CVE ID
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -74,7 +74,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 
-# Copyright (c) Trisha Pancho, 2023-2025
+# Copyright (c) Trisha Pancho, 2023-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nistnvd.json
+++ b/nistnvd.json
@@ -24,6 +24,12 @@
             "data_type": "string",
             "required": true,
             "order": 0
+        },
+        "verify_server_cert": {
+            "description": "Verify server SSL certificate",
+            "data_type": "boolean",
+            "default": true,
+            "order": 1
         }
     },
     "actions": [

--- a/nistnvd.json
+++ b/nistnvd.json
@@ -10,7 +10,7 @@
     "python_version": "3",
     "product_version_regex": ".*",
     "publisher": "Trisha Pancho",
-    "license": "Copyright (c) Trisha Pancho, 2023-2025",
+    "license": "Copyright (c) Trisha Pancho, 2023-2026",
     "app_version": "1.0.1",
     "utctime_updated": "2023-05-15T06:38:15.300199Z",
     "package_name": "phantom_nistnvd",
@@ -150,5 +150,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/nistnvd_connector.py
+++ b/nistnvd_connector.py
@@ -1,6 +1,6 @@
 # File: nistnvd_connector.py
 
-# Copyright (c) Trisha Pancho, 2023-2025
+# Copyright (c) Trisha Pancho, 2023-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -157,7 +157,7 @@ class NistNvdConnector(BaseConnector):
 
         self.save_progress("Connecting to endpoint")
         # make rest call
-        ret_val, response = self._make_rest_call(
+        ret_val, _response = self._make_rest_call(
             "/rest/json/cves/2.0?cveId=CVE-2019-1010218", action_result, method="get", params=None, headers=None
         )
 

--- a/nistnvd_connector.py
+++ b/nistnvd_connector.py
@@ -138,7 +138,7 @@ class NistNvdConnector(BaseConnector):
             r = request_func(
                 url,
                 # auth=(username, password),  # basic authentication
-                verify=config.get("verify_server_cert", False),
+                verify=config.get("verify_server_cert", True),
                 **kwargs,
             )
         except Exception as e:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Internal development tooling was refreshed for this connector.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Internal development tooling was refreshed for this connector.
+* TLS certificate verification is now enabled by default for NVD API requests, with an explicit asset setting to opt out when required.


### PR DESCRIPTION
## Description

Enable TLS certificate verification by default for NVD API requests while retaining an explicit asset-level opt-out for environments that require TLS interception.

Tracking:
- PAPP-37959
- PSAAS-31390
- Provenance: VULN-94115, FS-2269

The Flashpoint patch was used as guidance and matched the confirmed connector data flow. The pre-commit baseline commit temporarily added a chore note to satisfy the current shared hook; the functional commit replaced it, so the final unreleased notes contain only the user-visible TLS change.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Verification

- `pre-commit run --all-files`
- `python3 -m py_compile nistnvd_connector.py`
- `git diff --check`

No SOAR integration test was run because this legacy BaseConnector app requires a live SOAR environment.

Written by Codex.